### PR TITLE
Implement 1-4 scaling

### DIFF
--- a/examples/ethane_water_charge_only/ethane_water.xml
+++ b/examples/ethane_water_charge_only/ethane_water.xml
@@ -54,7 +54,7 @@
     <Atom charge="0.0" type="HA3" sigma="0.23876085646161097" epsilon="0.100416"/>
     <Atom charge="0.0" type="CT3" sigma="0.3634866770012585" epsilon="0.32635200000000003"/>
  </NonbondedForce>
- <MPIDForce>
+ <MPIDForce coulomb14scale="0.5" >
    <Multipole type="OW" c0="-0.834" />
    <Multipole type="HW" c0="0.417" />
    <Multipole type="HA3" c0="0.09" />

--- a/openmmapi/include/openmm/MPIDForce.h
+++ b/openmmapi/include/openmm/MPIDForce.h
@@ -453,13 +453,29 @@ public:
      */
     double getDefaultTholeWidth() const;
 
+    /**
+     * Set the 1-4 scale factor, which scales all (i.e.
+     * polarizable-fixed and fixed-fixed) interactions
+     *
+     * @param scaleFactor the scale factor for 1-4 interactions.
+     */
+    void set14ScaleFactor(double scaleFactor);
+
+    /**
+     * Get the 1-4 scale factor, which scales all (i.e.
+     * polarizable-fixed and fixed-fixed) interactions
+     *
+     * @returns the scale factor for 1-4 interactions.
+     */
+    double get14ScaleFactor() const;
+
 protected:
     ForceImpl* createImpl() const;
 private:
     NonbondedMethod nonbondedMethod;
     PolarizationType polarizationType;
     double cutoffDistance;
-    double alpha, defaultThole;
+    double alpha, defaultThole, scaleFactor14;
     int pmeBSplineOrder, nx, ny, nz;
     int mutualInducedMaxIterations;
     std::vector<double> extrapolationCoefficients;

--- a/openmmapi/src/MPIDForce.cpp
+++ b/openmmapi/src/MPIDForce.cpp
@@ -42,7 +42,7 @@ using std::vector;
 
 MPIDForce::MPIDForce() : nonbondedMethod(NoCutoff), polarizationType(Extrapolated), pmeBSplineOrder(6), cutoffDistance(1.0), ewaldErrorTol(5e-4), mutualInducedMaxIterations(60),
                                                mutualInducedTargetEpsilon(1.0e-02), scalingDistanceCutoff(100.0), electricConstant(138.9354558456), defaultThole(5.0),
-                                               alpha(0.0), nx(0), ny(0), nz(0) {
+                                               alpha(0.0), nx(0), ny(0), nz(0), scaleFactor14(1.0) {
     extrapolationCoefficients.push_back(-0.154);
     extrapolationCoefficients.push_back(0.017);
     extrapolationCoefficients.push_back(0.658);
@@ -149,6 +149,14 @@ double MPIDForce::getEwaldErrorTolerance() const {
 
 void MPIDForce::setEwaldErrorTolerance(double tol) {
     ewaldErrorTol = tol;
+}
+
+double MPIDForce::get14ScaleFactor() const {
+    return scaleFactor14;
+}
+
+void MPIDForce::set14ScaleFactor(double fac) {
+    scaleFactor14 = fac;
 }
 
 int MPIDForce::addMultipole(double charge, const std::vector<double>& molecularDipole, const std::vector<double>& molecularQuadrupole,

--- a/platforms/cuda/src/MPIDCudaKernels.cpp
+++ b/platforms/cuda/src/MPIDCudaKernels.cpp
@@ -458,6 +458,7 @@ void CudaCalcMPIDForceKernel::initialize(const System& system, const MPIDForce& 
         defines["USE_PERIODIC"] = "";
         defines["CUTOFF_SQUARED"] = cu.doubleToString(force.getCutoffDistance()*force.getCutoffDistance());
     }
+    defines["SCALEFACTOR14"] = cu.doubleToString(force.get14ScaleFactor());
     int maxThreads = cu.getNonbondedUtilities().getForceThreadBlockSize();
     fixedFieldThreads = min(maxThreads, cu.computeThreadBlockSize(fixedThreadMemory));
     inducedFieldThreads = min(maxThreads, cu.computeThreadBlockSize(inducedThreadMemory));

--- a/platforms/cuda/src/kernels/multipoleElectrostatics.cu
+++ b/platforms/cuda/src/kernels/multipoleElectrostatics.cu
@@ -49,14 +49,14 @@ __device__ float computeMScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : 1.0f);
+    return (x && y ? 0.0f : (float) SCALEFACTOR14);
 }
 
 __device__ float computePScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : 1.0f);
+    return (x && y ? 0.0f : (float) SCALEFACTOR14);
 }
 
 __device__ void computeOneInteraction(AtomData& atom1, AtomData& atom2, bool hasExclusions, float pScale, float mScale, float forceFactor, mixed& energy) {

--- a/platforms/cuda/src/kernels/multipoleFixedField.cu
+++ b/platforms/cuda/src/kernels/multipoleFixedField.cu
@@ -262,7 +262,7 @@ __device__ float computePScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : 1.0f);
+    return (x && y ? 0.0f : (float) SCALEFACTOR14);
 }
 
 /**

--- a/platforms/cuda/src/kernels/multipoleInducedField.cu
+++ b/platforms/cuda/src/kernels/multipoleInducedField.cu
@@ -25,7 +25,7 @@ __device__ float computePScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : 1.0f);
+    return (x && y ? 0.0f : (float) SCALEFACTOR14);
 }
 
 inline __device__ void zeroAtomData(AtomData& data) {

--- a/platforms/cuda/src/kernels/pmeMultipoleElectrostatics.cu
+++ b/platforms/cuda/src/kernels/pmeMultipoleElectrostatics.cu
@@ -49,7 +49,7 @@ __device__ float computeMScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : 1.0f);
+    return (x && y ? 0.0f : (float) SCALEFACTOR14);
 }
 
 

--- a/platforms/reference/src/MPIDReferenceKernels.cpp
+++ b/platforms/reference/src/MPIDReferenceKernels.cpp
@@ -171,6 +171,8 @@ void ReferenceCalcMPIDForceKernel::initialize(const System& system, const MPIDFo
     } else {
         usePme = false;
     }
+    scaleFactor14 = force.get14ScaleFactor();
+
     return;
 }
 
@@ -214,6 +216,7 @@ MPIDReferenceForce* ReferenceCalcMPIDForceKernel::setupMPIDReferenceForce(Contex
     } else {
         throw OpenMMException("Polarization type not recognzied.");
     }
+    mpidReferenceForce->set14ScaleFactor(scaleFactor14);
 
     return mpidReferenceForce;
 

--- a/platforms/reference/src/MPIDReferenceKernels.h
+++ b/platforms/reference/src/MPIDReferenceKernels.h
@@ -153,6 +153,7 @@ private:
     bool usePme;
     double alphaEwald;
     double defaultTholeWidth;
+    double scaleFactor14;
     double cutoffDistance;
     std::vector<int> pmeGridDimension;
 

--- a/platforms/reference/src/SimTKReference/MPIDReferenceForce.cpp
+++ b/platforms/reference/src/SimTKReference/MPIDReferenceForce.cpp
@@ -84,6 +84,17 @@ void MPIDReferenceForce::initialize()
     _pScale[index++]      = 1.0;
 }
 
+void MPIDReferenceForce::set14ScaleFactor(double factor)
+{
+    _pScale[3] = _mScale[3] = factor;
+}
+
+double MPIDReferenceForce::get14ScaleFactor() const
+{
+    assert(_pScale[3] == _mScale[3]);
+    return _pScale[3];
+}
+
 MPIDReferenceForce::NonbondedMethod MPIDReferenceForce::getNonbondedMethod() const
 {
     return _nonbondedMethod;

--- a/platforms/reference/src/SimTKReference/MPIDReferenceForce.h
+++ b/platforms/reference/src/SimTKReference/MPIDReferenceForce.h
@@ -555,6 +555,24 @@ public:
     double getMutualInducedDipoleTargetEpsilon() const;
 
     /**
+     * Set the scale permanent-permanent and permanent-induced scale factors
+     * for 1-4 connected connected atoms
+     *
+     * @param scaleFactor the factor by which the 1-4 interactions are scaled.
+     *
+     */
+    void set14ScaleFactor(double scaleFactor);
+
+    /**
+     * Get the scale permanent-permanent and permanent-induced scale factors
+     * for 1-4 connected connected atoms
+     *
+     * @return the factor by which the 1-4 interactions are scaled.
+     *
+     */
+    double get14ScaleFactor() const;
+
+    /**
      * Set the maximum number of iterations to be executed in converging mutual induced dipoles.
      *
      * @param maximumMutualInducedDipoleIterations maximum number of iterations to be executed in converging mutual induced dipoles

--- a/platforms/reference/tests/TestReferenceMPIDForce.cpp
+++ b/platforms/reference/tests/TestReferenceMPIDForce.cpp
@@ -61,6 +61,51 @@ extern "C" OPENMM_EXPORT void registerMPIDReferenceKernelFactories();
 
 const double TOL = 1e-4;
 
+void make_charge_square(double boxEdgeLength, vector<Vec3> &positions, MPIDForce *forceField, System &system)
+{
+    positions.clear();
+
+    // 0  3
+    // |  |
+    // 1--2
+
+    // Atom 0
+    positions.push_back(Vec3(0.1, 0.0, 0.0));
+    forceField->addMultipole(1.0, {0,0,0}, {0,0,0,0,0,0}, {0,0,0,0,0,0,0,0,0,0}, MPIDForce::NoAxisType, 0, 0, 0, 0.0, {0.0, 0.0, 0.0});
+    system.addParticle(1.0);
+    forceField->setCovalentMap(0, MPIDForce::Covalent12, {1});
+    forceField->setCovalentMap(0, MPIDForce::Covalent13, {2});
+    forceField->setCovalentMap(0, MPIDForce::Covalent14, {3});
+
+    // Atom 1
+    positions.push_back(Vec3(0.0, 0.0, 0.0));
+    forceField->addMultipole(1.0, {0,0,0}, {0,0,0,0,0,0}, {0,0,0,0,0,0,0,0,0,0}, MPIDForce::NoAxisType, 0, 0, 0, 0.0, {0.0, 0.0, 0.0});
+    system.addParticle(1.0);
+    forceField->setCovalentMap(1, MPIDForce::Covalent12, {0, 2});
+    forceField->setCovalentMap(1, MPIDForce::Covalent13, {3});
+
+    // Atom 2
+    positions.push_back(Vec3(0.0, 0.1, 0.0));
+    forceField->addMultipole(-1.0, {0,0,0}, {0,0,0,0,0,0}, {0,0,0,0,0,0,0,0,0,0}, MPIDForce::NoAxisType, 0, 0, 0, 0.0, {0.0, 0.0, 0.0});
+    system.addParticle(1.0);
+    forceField->setCovalentMap(2, MPIDForce::Covalent12, {1, 3});
+    forceField->setCovalentMap(2, MPIDForce::Covalent13, {0});
+
+    // Atom 3
+    positions.push_back(Vec3(0.1, 0.1, 0.0));
+    forceField->addMultipole(-1.0, {0,0,0}, {0,0,0,0,0,0}, {0,0,0,0,0,0,0,0,0,0}, MPIDForce::NoAxisType, 0, 0, 0, 0.0, {0.0, 0.0, 0.0});
+    system.addParticle(1.0);
+    forceField->setCovalentMap(3, MPIDForce::Covalent12, {2});
+    forceField->setCovalentMap(3, MPIDForce::Covalent13, {1});
+    forceField->setCovalentMap(3, MPIDForce::Covalent14, {0});
+
+    system.setDefaultPeriodicBoxVectors(Vec3(boxEdgeLength, 0, 0),
+                                        Vec3(0, boxEdgeLength, 0),
+                                        Vec3(0, 0, boxEdgeLength));
+
+}
+
+
 void make_waterbox(int natoms, double boxEdgeLength, MPIDForce *forceField,  vector<Vec3> &positions, System &system,
                    bool do_charge = true, bool do_dpole = true, bool do_qpole = true, bool do_opole = true, bool do_pol = true)
 {
@@ -1555,6 +1600,104 @@ void testWaterDimerEnergyAndForcesNoCutExtrapolated() {
 //    check_full_finite_differences(forces, context, positions, 1E-4, 1E-4);
 }
 
+void test14ScalingNoCutoff() {
+    // Water box with isotropic induced dipoles
+    double boxEdgeLength = 20*OpenMM::NmPerAngstrom;
+    MPIDForce* forceField1 = new MPIDForce();
+    MPIDForce* forceField2 = new MPIDForce();
+    MPIDForce* forceField3 = new MPIDForce();
+    vector<Vec3> positions;
+
+    double energy;
+    System system1, system2, system3;
+    State state;
+
+    make_charge_square(boxEdgeLength, positions, forceField1, system1);
+    forceField1->setNonbondedMethod(OpenMM::MPIDForce::NoCutoff);
+    system1.addForce(forceField1);
+    VerletIntegrator integrator1(0.01);
+    Context context1(system1, integrator1, Platform::getPlatformByName("Reference"));
+    context1.setPositions(positions);
+    state = context1.getState(State::Forces | State::Energy);
+    energy = state.getPotentialEnergy();
+    ASSERT_EQUAL_TOL(energy, -1389.35, 1E-5);
+
+    make_charge_square(boxEdgeLength, positions, forceField2, system2);
+    forceField2->setNonbondedMethod(OpenMM::MPIDForce::NoCutoff);
+    forceField2->set14ScaleFactor(0.5);
+    system2.addForce(forceField2);
+    VerletIntegrator integrator2(0.01);
+    Context context2(system2, integrator2, Platform::getPlatformByName("Reference"));
+    context2.setPositions(positions);
+    state = context2.getState(State::Forces | State::Energy);
+    energy = state.getPotentialEnergy();
+    ASSERT_EQUAL_TOL(energy, -1389.35/2, 1E-5);
+
+    make_charge_square(boxEdgeLength, positions, forceField3, system3);
+    forceField3->setNonbondedMethod(OpenMM::MPIDForce::NoCutoff);
+    forceField3->set14ScaleFactor(0.0);
+    system3.addForce(forceField3);
+    VerletIntegrator integrator3(0.01);
+    Context context3(system3, integrator3, Platform::getPlatformByName("Reference"));
+    context3.setPositions(positions);
+    state = context3.getState(State::Forces | State::Energy);
+    energy = state.getPotentialEnergy();
+    ASSERT_EQUAL_TOL(energy, 0.0, 1E-5);
+}
+
+void test14ScalingPME() {
+    // Water box with isotropic induced dipoles
+    const double cutoff = 4.0*OpenMM::NmPerAngstrom;
+    double boxEdgeLength = 40*OpenMM::NmPerAngstrom;
+    const int grid = 64;
+    MPIDForce* forceField1 = new MPIDForce();
+    MPIDForce* forceField2 = new MPIDForce();
+    MPIDForce* forceField3 = new MPIDForce();
+    vector<Vec3> positions;
+
+    double energy;
+    System system1, system2, system3;
+    State state;
+
+    make_charge_square(boxEdgeLength, positions, forceField1, system1);
+    forceField1->setNonbondedMethod(OpenMM::MPIDForce::PME);
+    forceField1->setCutoffDistance(cutoff);
+    forceField1->setPMEParameters(0.001, grid, grid, grid);
+    system1.addForce(forceField1);
+    VerletIntegrator integrator1(0.01);
+    Context context1(system1, integrator1, Platform::getPlatformByName("Reference"));
+    context1.setPositions(positions);
+    state = context1.getState(State::Forces | State::Energy);
+    energy = state.getPotentialEnergy();
+    ASSERT_EQUAL_TOL(energy, -1389.35, 1E-3);
+
+    make_charge_square(boxEdgeLength, positions, forceField2, system2);
+    forceField2->setNonbondedMethod(OpenMM::MPIDForce::PME);
+    forceField2->setCutoffDistance(cutoff);
+    forceField2->setPMEParameters(0.001, grid, grid, grid);
+    forceField2->set14ScaleFactor(0.5);
+    system2.addForce(forceField2);
+    VerletIntegrator integrator2(0.01);
+    Context context2(system2, integrator2, Platform::getPlatformByName("Reference"));
+    context2.setPositions(positions);
+    state = context2.getState(State::Forces | State::Energy);
+    energy = state.getPotentialEnergy();
+    ASSERT_EQUAL_TOL(energy, -1389.35/2, 1E-3);
+
+    make_charge_square(boxEdgeLength, positions, forceField3, system3);
+    forceField3->setNonbondedMethod(OpenMM::MPIDForce::PME);
+    forceField3->setCutoffDistance(cutoff);
+    forceField3->setPMEParameters(0.001, grid, grid, grid);
+    forceField3->set14ScaleFactor(0.0);
+    system3.addForce(forceField3);
+    VerletIntegrator integrator3(0.01);
+    Context context3(system3, integrator3, Platform::getPlatformByName("Reference"));
+    context3.setPositions(positions);
+    state = context3.getState(State::Forces | State::Energy);
+    energy = state.getPotentialEnergy();
+    ASSERT_EQUAL_TOL(energy, 0.0, 1E-3);
+}
+
 
 int main(int numberOfArguments, char* argv[]) {
 
@@ -1562,6 +1705,8 @@ int main(int numberOfArguments, char* argv[]) {
         std::cout << "TestReferenceMPIDForce running test..." << std::endl;
         registerMPIDReferenceKernelFactories();
 
+        test14ScalingNoCutoff();
+        test14ScalingPME();
         testWaterDimerEnergyAndForcesPMEDirect();
         testWaterDimerEnergyAndForcesNoCutDirect();
         testWaterDimerEnergyAndForcesPMEMutual();

--- a/serialization/src/MPIDForceProxy.cpp
+++ b/serialization/src/MPIDForceProxy.cpp
@@ -83,6 +83,7 @@ void MPIDForceProxy::serialize(const void* object, SerializationNode& node) cons
     node.setDoubleProperty("aEwald",                        alpha);
     node.setDoubleProperty("mutualInducedTargetEpsilon",    force.getMutualInducedTargetEpsilon());
     node.setDoubleProperty("ewaldErrorTolerance",           force.getEwaldErrorTolerance());
+    node.setDoubleProperty("scaleFactor14",                 force.get14ScaleFactor());
 
     SerializationNode& gridDimensionsNode  = node.createChildNode("MultipoleParticleGridDimension");
     gridDimensionsNode.setIntProperty("d0", nx).setIntProperty("d1", ny).setIntProperty("d2", nz); 
@@ -163,6 +164,7 @@ void* MPIDForceProxy::deserialize(const SerializationNode& node) const {
         force->setCutoffDistance(node.getDoubleProperty("cutoffDistance"));
         force->setMutualInducedTargetEpsilon(node.getDoubleProperty("mutualInducedTargetEpsilon"));
         force->setEwaldErrorTolerance(node.getDoubleProperty("ewaldErrorTolerance"));
+        force->set14ScaleFactor(node.getDoubleProperty("scaleFactor14"));
 
         const SerializationNode& gridDimensionsNode  = node.getChildNode("MultipoleParticleGridDimension");
         force->setPMEParameters(node.getDoubleProperty("aEwald"), gridDimensionsNode.getIntProperty("d0"), gridDimensionsNode.getIntProperty("d1"), gridDimensionsNode.getIntProperty("d2"));

--- a/serialization/tests/TestSerializeMPIDForce.cpp
+++ b/serialization/tests/TestSerializeMPIDForce.cpp
@@ -76,6 +76,7 @@ void testSerialization() {
     force1.setMutualInducedTargetEpsilon(1.0e-05); 
     //force1.setElectricConstant(138.93); 
     force1.setEwaldErrorTolerance(1.0e-05); 
+    force1.set14ScaleFactor(0.4);
     
     vector<double> coeff;
     coeff.push_back(0.0);
@@ -128,6 +129,7 @@ void testSerialization() {
     ASSERT_EQUAL(force1.getMutualInducedMaxIterations(),    force2.getMutualInducedMaxIterations());
     ASSERT_EQUAL(force1.getMutualInducedTargetEpsilon(),    force2.getMutualInducedTargetEpsilon());
     ASSERT_EQUAL(force1.getEwaldErrorTolerance(),           force2.getEwaldErrorTolerance());
+    ASSERT_EQUAL(force1.get14ScaleFactor(),                 force2.get14ScaleFactor());
 
 
     std::vector<int> gridDimension1;


### PR DESCRIPTION
The plugin currently doesn't scale 1-4 interactions because the MPID force field handles them completely unscaled (with 1-2 and 1-3 interactions neglected).  This PR allows the default 1-4 scale factor to be specified in the XML force field file and/or the argument list to `forcefield.createSystem()`.