### PR TITLE
Cleanup XML files

### DIFF
--- a/examples/parameters/swm4.xml
+++ b/examples/parameters/swm4.xml
@@ -1,14 +1,14 @@
 <!-- SWM4 water parameters file. Note that the atom types "name" are numeric - this is because of how AMOEBA/MPID assign anchor atoms -->
 <ForceField>
  <AtomTypes>
-  <Type name="380" class="OW" element="O" mass="15.999"/>
-  <Type name="381" class="HW" element="H" mass="1.008"/>
+  <Type name="OT" class="OW" element="O" mass="15.999"/>
+  <Type name="HT" class="HW" element="H" mass="1.008"/>
  </AtomTypes>
  <Residues>
   <Residue name="HOH">
-   <Atom name="H1" type="381"/>
-   <Atom name="H2" type="381"/>
-   <Atom name="O" type="380"/>
+   <Atom name="H1" type="HT"/>
+   <Atom name="H2" type="HT"/>
+   <Atom name="O" type="OT"/>
    <Bond from="0" to="2"/>
    <Bond from="1" to="2"/>
  </Residue>
@@ -20,24 +20,24 @@
   <Angle class1="HW" class2="OW" class3="HW" angle="1.82421813418" k="460.24"/>
  </HarmonicAngleForce>
  <NonbondedForce coulomb14scale="0.833333" lj14scale="1">
-  <Atom type="380" charge="-0.0" sigma="0.318394549" epsilon="0.882586558"/>
-  <Atom type="381" charge="0.0" sigma="1" epsilon="0"/>
+  <Atom type="OT" charge="-0.0" sigma="0.318394549" epsilon="0.882586558"/>
+  <Atom type="HT" charge="0.0" sigma="1" epsilon="0"/>
  </NonbondedForce>
  <MPIDForce>
-   <Multipole type="380" kz="-381" kx="-381"
+   <Multipole type="OT" kz="-HT" kx="-HT"
              c0="-1.11466"
              dX="0.0" dY="0.0"  dZ="-0.026790125"
              qXX="0.000107316" qXY="0.0" qYY="0.000107316" qXZ="0.0" qYZ="0.0" qZZ="-0.000214633"
              oXXX="0.0" oXXY="0.0" oXYY="0.0" oYYY="0.0" oXXZ="0.000000516" oXYZ="0.0" oYYZ="0.000000516" oXZZ="0.0" oYZZ="0.0" oZZZ="-0.000001032"
              />
-   <Multipole type="381" kz="380" kx="381"
+   <Multipole type="HT" kz="OT" kx="HT"
              c0="0.55733"
              dX="0.0" dY="0.0"  dZ="0.0"
              qXX="0.0" qXY="0.0" qYY="0.0" qXZ="0.0" qYZ="0.0" qZZ="0.0"
              oXXX="0.0" oXXY="0.0" oXYY="0.0" oYYY="0.0" oXXZ="0.0" oXYZ="0.0" oYYZ="0.0" oXZZ="0.0" oYZZ="0.0" oZZZ="0.0"
              />
-   <Polarize type="380" polarizabilityXX="0.000978253" polarizabilityYY="0.000978253" polarizabilityZZ="0.000978253" thole="8.0"/>
-   <Polarize type="381" polarizabilityXX="0.000" polarizabilityYY="0.000" polarizabilityZZ="0.000" thole="0.0"/>
+   <Polarize type="OT" polarizabilityXX="0.000978253" polarizabilityYY="0.000978253" polarizabilityZZ="0.000978253" thole="8.0"/>
+   <Polarize type="HT" polarizabilityXX="0.000" polarizabilityYY="0.000" polarizabilityZZ="0.000" thole="0.0"/>
  </MPIDForce>
 </ForceField>
 

--- a/examples/parameters/swm6.xml
+++ b/examples/parameters/swm6.xml
@@ -1,14 +1,14 @@
 <!-- Note that the atom types "name" are numeric - this is because of how AMOEBA/MPID assign anchor atoms -->
 <ForceField>
  <AtomTypes>
-  <Type name="380" class="OW" element="O" mass="15.999"/>
-  <Type name="381" class="HW" element="H" mass="1.008"/>
+  <Type name="OT" class="OW" element="O" mass="15.999"/>
+  <Type name="HT" class="HW" element="H" mass="1.008"/>
  </AtomTypes>
  <Residues>
   <Residue name="HOH">
-   <Atom name="H1" type="381"/>
-   <Atom name="H2" type="381"/>
-   <Atom name="O" type="380"/>
+   <Atom name="H1" type="HT"/>
+   <Atom name="H2" type="HT"/>
+   <Atom name="O" type="OT"/>
    <Bond from="0" to="2"/>
    <Bond from="1" to="2"/>
  </Residue>
@@ -20,24 +20,24 @@
   <Angle class1="HW" class2="OW" class3="HW" angle="1.82421813418" k="460.24"/>
  </HarmonicAngleForce>
  <NonbondedForce coulomb14scale="0.833333" lj14scale="0.5">
-  <Atom type="380" charge="-0.0" sigma="0.31983264" epsilon="0.677808"/>
-  <Atom type="381" charge="0.0" sigma="1" epsilon="0"/>
+  <Atom type="OT" charge="-0.0" sigma="0.31983264" epsilon="0.677808"/>
+  <Atom type="HT" charge="0.0" sigma="1" epsilon="0"/>
  </NonbondedForce>
  <MPIDForce>
-   <Multipole type="380" kz="-381" kx="-381"
+   <Multipole type="OT" kz="-HT" kx="-HT"
              c0="-1.0614"
              dX="0.0" dY="0.0"  dZ="-0.023671684"
              qXX="0.000150963" qXY="0.0" qYY="0.00008707" qXZ="0.0" qYZ="0.0" qZZ="-0.000238034"
              oXXX="0.0" oXXY="0.0" oXYY="0.0" oYYY="0.0" oXXZ="0.000000426" oXYZ="0.0" oYYZ="0.000000853" oXZZ="0.0" oYZZ="0.0" oZZZ="-0.000001279"
              />
-   <Multipole type="381" kz="380" kx="381"
+   <Multipole type="HT" kz="OT" kx="HT"
              c0="0.5307"
              dX="0.0" dY="0.0"  dZ="0.0"
              qXX="0.0" qXY="0.0" qYY="0.0" qXZ="0.0" qYZ="0.0" qZZ="0.0"
              oXXX="0.0" oXXY="0.0" oXYY="0.0" oYYY="0.0" oXXZ="0.0" oXYZ="0.0" oYYZ="0.0" oXZZ="0.0" oYZZ="0.0" oZZZ="0.0"
              />
-   <Polarize type="380" polarizabilityXX="0.00088" polarizabilityYY="0.00088" polarizabilityZZ="0.00088" thole="8.0"/>
-   <Polarize type="381" polarizabilityXX="0.000" polarizabilityYY="0.000" polarizabilityZZ="0.000" thole="0.0"/>
+   <Polarize type="OT" polarizabilityXX="0.00088" polarizabilityYY="0.00088" polarizabilityZZ="0.00088" thole="8.0"/>
+   <Polarize type="HT" polarizabilityXX="0.000" polarizabilityYY="0.000" polarizabilityZZ="0.000" thole="0.0"/>
  </MPIDForce>
 </ForceField>
 

--- a/examples/waterbox/run.py
+++ b/examples/waterbox/run.py
@@ -10,8 +10,8 @@ import numpy as np
 pdb = PDBFile('waterbox_31ang.pdb')
 
 #forcefield = ForceField('../parameters/tip3p.xml')
-#forcefield = ForceField('../parameters/swm6.xml')
-forcefield = ForceField('../parameters/swm4.xml')
+#forcefield = ForceField('../parameters/swm4.xml')
+forcefield = ForceField('../parameters/swm6.xml')
 system = forcefield.createSystem(pdb.topology, nonbondedMethod=LJPME, nonbondedCutoff=8*angstrom, constraints=HBonds,
                                  defaultTholeWidth=8)
 integrator = LangevinIntegrator(300*kelvin, 1/picosecond, 2*femtoseconds)


### PR DESCRIPTION
The atom types used for MPID need not be numerical anymore; this PR updates the examples to reflect that change.