### PR TITLE
Allow defaultTholeWidth in XML tag

### DIFF
--- a/examples/parameters/swm4.xml
+++ b/examples/parameters/swm4.xml
@@ -1,4 +1,3 @@
-<!-- SWM4 water parameters file. Note that the atom types "name" are numeric - this is because of how AMOEBA/MPID assign anchor atoms -->
 <ForceField>
  <AtomTypes>
   <Type name="OT" class="OW" element="O" mass="15.999"/>
@@ -40,6 +39,3 @@
    <Polarize type="HT" polarizabilityXX="0.000" polarizabilityYY="0.000" polarizabilityZZ="0.000" thole="0.0"/>
  </MPIDForce>
 </ForceField>
-
-<!--  Dump unwanted parameters here!
--->

--- a/examples/parameters/swm6.xml
+++ b/examples/parameters/swm6.xml
@@ -1,4 +1,3 @@
-<!-- Note that the atom types "name" are numeric - this is because of how AMOEBA/MPID assign anchor atoms -->
 <ForceField>
  <AtomTypes>
   <Type name="OT" class="OW" element="O" mass="15.999"/>
@@ -40,6 +39,3 @@
    <Polarize type="HT" polarizabilityXX="0.000" polarizabilityYY="0.000" polarizabilityZZ="0.000" thole="0.0"/>
  </MPIDForce>
 </ForceField>
-
-<!--  Dump unwanted parameters here!
--->


### PR DESCRIPTION
This PR allows the defaultTholeWidth argument to be placed as a tag in the XML format, as well as in the `createSystem()` method of `ForceField`.