### PR TITLE
Fix the 1-4 scale factor and Vec3 in getInducedDipoles

### DIFF
--- a/platforms/cuda/src/kernels/multipoleElectrostatics.cu
+++ b/platforms/cuda/src/kernels/multipoleElectrostatics.cu
@@ -49,14 +49,14 @@ __device__ float computeMScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : (float) SCALEFACTOR14);
+	return (x ? (y ? 0.0f : (float) SCALEFACTOR14): 1.0f);
 }
 
 __device__ float computePScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : (float) SCALEFACTOR14);
+	return (x ? (y ? 0.0f : (float) SCALEFACTOR14): 1.0f);
 }
 
 __device__ void computeOneInteraction(AtomData& atom1, AtomData& atom2, bool hasExclusions, float pScale, float mScale, float forceFactor, mixed& energy) {

--- a/platforms/cuda/src/kernels/multipoleFixedField.cu
+++ b/platforms/cuda/src/kernels/multipoleFixedField.cu
@@ -262,7 +262,7 @@ __device__ float computePScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : (float) SCALEFACTOR14);
+	return (x ? (y ? 0.0f : (float) SCALEFACTOR14): 1.0f);
 }
 
 /**

--- a/platforms/cuda/src/kernels/multipoleInducedField.cu
+++ b/platforms/cuda/src/kernels/multipoleInducedField.cu
@@ -25,7 +25,7 @@ __device__ float computePScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : (float) SCALEFACTOR14);
+	return (x ? (y ? 0.0f : (float) SCALEFACTOR14): 1.0f);
 }
 
 inline __device__ void zeroAtomData(AtomData& data) {

--- a/platforms/cuda/src/kernels/pmeMultipoleElectrostatics.cu
+++ b/platforms/cuda/src/kernels/pmeMultipoleElectrostatics.cu
@@ -49,7 +49,7 @@ __device__ float computeMScaleFactor(uint2 covalent, int index) {
     int mask = 1<<index;
     bool x = (covalent.x & mask);
     bool y = (covalent.y & mask);
-    return (x && y ? 0.0f : (float) SCALEFACTOR14);
+	return (x ? (y ? 0.0f : (float) SCALEFACTOR14): 1.0f);
 }
 
 

--- a/python/header.i
+++ b/python/header.i
@@ -1,0 +1,34 @@
+
+%header %{
+namespace OpenMM {
+
+PyObject *copyVVec3ToList(std::vector<Vec3> vVec3) {
+  int i, n;
+  PyObject *pyList;
+
+  n=vVec3.size(); 
+  pyList=PyList_New(n);
+  PyObject* mm = PyImport_AddModule("openmm");
+  PyObject* vec3 = PyObject_GetAttrString(mm, "Vec3");
+  for (i=0; i<n; i++) {
+    OpenMM::Vec3& v = vVec3.at(i);
+    PyObject* args = Py_BuildValue("(d,d,d)", v[0], v[1], v[2]);
+    PyObject* pyVec = PyObject_CallObject(vec3, args);
+    Py_DECREF(args);
+    PyList_SET_ITEM(pyList, i, pyVec);
+  }
+  return pyList;
+}
+
+int isNumpyAvailable() {
+    static bool initialized = false;
+    static bool available = false;
+    if (!initialized) {
+        initialized = true;
+        available = (_import_array() >= 0);
+    }
+    return available;
+}
+
+} // namespace OpenMM
+%}

--- a/python/mpidplugin.i
+++ b/python/mpidplugin.i
@@ -1,5 +1,6 @@
 %module mpidplugin
 
+%include "factory.i"
 %import(module="openmm") "swig/OpenMMSwigHeaders.i"
 %include "swig/typemaps.i"
 

--- a/python/mpidplugin.i
+++ b/python/mpidplugin.i
@@ -23,6 +23,9 @@ namespace std {
 #include "OpenMMDrude.h"
 #include "openmm/RPMDIntegrator.h"
 #include "openmm/RPMDMonteCarloBarostat.h"
+
+using namespace OpenMM;
+using OpenMM::Vec3;
 %}
 
 %pythoncode %{
@@ -33,6 +36,11 @@ import openmm.unit as unit
 /*
  * Add units to function outputs.
 */
+
+%{
+#include <numpy/arrayobject.h>
+%}
+%include "header.i"
 
 namespace OpenMM {
 
@@ -430,18 +438,18 @@ public:
      * @param context         the Context for which to get the fixed dipoles
      * @param[out] dipoles    the fixed dipole moment of particle i is stored into the i'th element
      */
-    %apply std::vector<OpenMM::Vec3>& OUTPUT { std::vector<OpenMM::Vec3>& dipoles };
-    void getLabFramePermanentDipoles(Context& context, std::vector<OpenMM::Vec3>& dipoles);
-    %clear std::vector<OpenMM::Vec3>& dipoles;
+    %apply std::vector<Vec3>& OUTPUT { std::vector<Vec3>& dipoles };
+    void getLabFramePermanentDipoles(Context& context, std::vector<Vec3>& dipoles);
+    %clear std::vector<Vec3>& dipoles;
     /**
      * Get the induced dipole moments of all particles.
      *
      * @param context         the Context for which to get the induced dipoles
      * @param[out] dipoles    the induced dipole moment of particle i is stored into the i'th element
      */
-    %apply std::vector<OpenMM::Vec3>& OUTPUT { std::vector<OpenMM::Vec3>& dipoles };
-    void getInducedDipoles(Context& context, std::vector<OpenMM::Vec3>& dipoles);
-    %clear std::vector<OpenMM::Vec3>& dipoles;
+    %apply std::vector<Vec3>& OUTPUT { std::vector<Vec3>& dipoles };
+    void getInducedDipoles(Context& context, std::vector<Vec3>& dipoles);
+    %clear std::vector<Vec3>& dipoles;
 
     /**
      * Get the total dipole moments (fixed plus induced) of all particles.
@@ -449,9 +457,9 @@ public:
      * @param context         the Context for which to get the total dipoles
      * @param[out] dipoles    the total dipole moment of particle i is stored into the i'th element
      */
-    %apply std::vector<OpenMM::Vec3>& OUTPUT { std::vector<OpenMM::Vec3>& dipoles };
-    void getTotalDipoles(Context& context, std::vector<OpenMM::Vec3>& dipoles);
-    %clear std::vector<OpenMM::Vec3>& dipoles;
+    %apply std::vector<Vec3>& OUTPUT { std::vector<Vec3>& dipoles };
+    void getTotalDipoles(Context& context, std::vector<Vec3>& dipoles);
+    %clear std::vector<Vec3>& dipoles;
 
     /**
      * Get the electrostatic potential.
@@ -461,7 +469,7 @@ public:
      * @param[out] outputElectrostaticPotential output potential
      */
     %apply std::vector<double>& OUTPUT { std::vector<double>& outputElectrostaticPotential };
-    void getElectrostaticPotential(const std::vector< OpenMM::Vec3 >& inputGrid,
+    void getElectrostaticPotential(const std::vector<Vec3>& inputGrid,
                                     Context& context, std::vector< double >& outputElectrostaticPotential);
     %clear std::vector<double>& outputElectrostaticPotential;
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,6 +3,7 @@ from distutils.extension import Extension
 import os
 import sys
 import platform
+import numpy
 
 openmm_dir = '@OPENMM_DIR@'
 mpidplugin_header_dir = '@MPIDPLUGIN_HEADER_DIR@'
@@ -19,7 +20,7 @@ if platform.system() == 'Darwin':
 extension = Extension(name='_mpidplugin',
                       sources=['MPIDPluginWrapper.cpp'],
                       libraries=['OpenMM', 'MPIDPlugin'],
-                      include_dirs=[os.path.join(openmm_dir, 'include'), mpidplugin_header_dir],
+                      include_dirs=[os.path.join(openmm_dir, 'include'), mpidplugin_header_dir, numpy.get_include()],
                       library_dirs=[os.path.join(openmm_dir, 'lib'), mpidplugin_library_dir],
                       extra_compile_args=extra_compile_args,
                       extra_link_args=extra_link_args


### PR DESCRIPTION
This PR proposes a fix to the problems in the 1-4 scale factor and getInducedDipoles discussed in #10 and #12, respectively. The proposed fix for `Vec3` needs to use `numpy<2`.